### PR TITLE
Add multilingual pages and dynamic translation support

### DIFF
--- a/www/en/index.html
+++ b/www/en/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Interactive map of Lunaret Zoo with real-time geolocation. Explore the zoo and find your way easily.">
+  <title>Interactive map of Lunaret Zoo</title>
+  <link rel="stylesheet" href="../styles.css?v=5">
+  <link rel="manifest" href="../manifest.json">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="alternate" hreflang="fr" href="../index.html">
+  <link rel="alternate" hreflang="en" href="./index.html">
+  <link rel="alternate" hreflang="es" href="../es/index.html">
+  <link rel="alternate" hreflang="nl-BE" href="../nl-be/index.html">
+</head>
+<body>
+  <div id="map-container">
+    <img id="carte" src="../img/plan.webp" alt="Map of Lunaret Zoo" class="fullscreen-img">
+    <canvas id="trail-canvas"></canvas>    
+  </div>
+  <div id="out-of-bounds-panel">    
+    <div class="panel-content">
+      <div class="panel-text">You are outside the park, follow the arrow</div>
+      <div class="arrow-container">
+        <svg id="direction-arrow" width="60" height="60" viewBox="0 0 60 60">
+          <polygon points="30,8 40,38 30,32 20,38" fill="#007bff" stroke="#333" stroke-width="2" />
+        </svg>
+      </div>
+    </div>
+    <button class="panel-hide-btn" id="out-of-bounds-hide-btn" aria-label="Minimize panel" title="Minimize">
+      <svg width="38" height="38" viewBox="0 0 24 24">
+        <path fill="#000000" d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z"/>
+      </svg>
+    </button>
+  </div>
+  <button id="fullscreen-btn" aria-label="Fullscreen">
+    <svg viewBox="0 0 24 24" width="24" height="24">
+      <path fill="currentColor" d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>
+    </svg>
+  </button>
+  <div id="gps-waiting-notification">
+    <button class="hide-btn" id="gps-notif-hide" title="Hide notification">Hide</button>
+      Waiting for GPS signal…
+  </div>
+</body>
+<script src="../index.js?v=7"></script>
+</html>

--- a/www/es/index.html
+++ b/www/es/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Mapa interactivo del Zoo de Lunaret con geolocalización en tiempo real. Explora el zoo y encuentra tu camino fácilmente.">
+  <title>Mapa interactivo del Zoo de Lunaret</title>
+  <link rel="stylesheet" href="../styles.css?v=5">
+  <link rel="manifest" href="../manifest.json">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="alternate" hreflang="fr" href="../index.html">
+  <link rel="alternate" hreflang="en" href="../en/index.html">
+  <link rel="alternate" hreflang="es" href="./index.html">
+  <link rel="alternate" hreflang="nl-BE" href="../nl-be/index.html">
+</head>
+<body>
+  <div id="map-container">
+    <img id="carte" src="../img/plan.webp" alt="Mapa del Zoo de Lunaret" class="fullscreen-img">
+    <canvas id="trail-canvas"></canvas>    
+  </div>
+  <div id="out-of-bounds-panel">    
+    <div class="panel-content">
+      <div class="panel-text">Estás fuera del parque, sigue la flecha</div>
+      <div class="arrow-container">
+        <svg id="direction-arrow" width="60" height="60" viewBox="0 0 60 60">
+          <polygon points="30,8 40,38 30,32 20,38" fill="#007bff" stroke="#333" stroke-width="2" />
+        </svg>
+      </div>
+    </div>
+    <button class="panel-hide-btn" id="out-of-bounds-hide-btn" aria-label="Minimizar el panel" title="Minimizar">
+      <svg width="38" height="38" viewBox="0 0 24 24">
+        <path fill="#000000" d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z"/>
+      </svg>
+    </button>
+  </div>
+  <button id="fullscreen-btn" aria-label="Pantalla completa">
+    <svg viewBox="0 0 24 24" width="24" height="24">
+      <path fill="currentColor" d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>
+    </svg>
+  </button>
+  <div id="gps-waiting-notification">
+    <button class="hide-btn" id="gps-notif-hide" title="Ocultar la notificación">Ocultar</button>
+      Esperando la señal GPS…
+  </div>
+</body>
+<script src="../index.js?v=7"></script>
+</html>

--- a/www/i18n/en.json
+++ b/www/i18n/en.json
@@ -1,0 +1,5 @@
+{
+  "expand": "Expand",
+  "geolocation_error": "Geolocation error: {code} - {message}",
+  "geolocation_unsupported": "Geolocation is not supported by this browser."
+}

--- a/www/i18n/es.json
+++ b/www/i18n/es.json
@@ -1,0 +1,5 @@
+{
+  "expand": "Ampliar",
+  "geolocation_error": "Error de geolocalización: {code} - {message}",
+  "geolocation_unsupported": "La geolocalización no es compatible con este navegador."
+}

--- a/www/i18n/fr.json
+++ b/www/i18n/fr.json
@@ -1,0 +1,5 @@
+{
+  "expand": "Agrandir",
+  "geolocation_error": "Erreur de géolocalisation : {code} - {message}",
+  "geolocation_unsupported": "La géolocalisation n'est pas supportée par ce navigateur."
+}

--- a/www/i18n/nl-BE.json
+++ b/www/i18n/nl-BE.json
@@ -1,0 +1,5 @@
+{
+  "expand": "Vergroten",
+  "geolocation_error": "Geolocatiefout: {code} - {message}",
+  "geolocation_unsupported": "Geolocatie wordt niet ondersteund door deze browser."
+}

--- a/www/index.html
+++ b/www/index.html
@@ -5,16 +5,28 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Plan interactif du Zoo du Lunaret avec géolocalisation en temps réel. Explorez le zoo et trouvez votre chemin facilement.">
   <title>Plan interactif du Zoo du Lunaret</title>
+  <script>
+    (function() {
+      var lang = (navigator.language || '').toLowerCase();
+      if (lang.startsWith('en')) location.replace('en/index.html');
+      else if (lang.startsWith('es')) location.replace('es/index.html');
+      else if (lang.startsWith('nl')) location.replace('nl-be/index.html');
+    })();
+  </script>
   <link rel="stylesheet" href="styles.css?v=5">
   <link rel="manifest" href="manifest.json">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="alternate" hreflang="fr" href="./index.html">
+  <link rel="alternate" hreflang="en" href="en/index.html">
+  <link rel="alternate" hreflang="es" href="es/index.html">
+  <link rel="alternate" hreflang="nl-BE" href="nl-be/index.html">
 </head>
 <body>
   <div id="map-container">
     <img id="carte" src="img/plan.webp" alt="Carte du Zoo du Lunaret" class="fullscreen-img">
-    <canvas id="trail-canvas"></canvas>    
+    <canvas id="trail-canvas"></canvas>
   </div>
-  <div id="out-of-bounds-panel">    
+  <div id="out-of-bounds-panel">
     <div class="panel-content">
       <div class="panel-text">Vous êtes en dehors du parc, suivez la flèche</div>
       <div class="arrow-container">

--- a/www/index.js
+++ b/www/index.js
@@ -1,7 +1,56 @@
 // Enregistrement du service worker pour la mise en cache
+const pathPrefix = window.location.pathname.split('/').filter(Boolean).length > 1 ? '../' : './';
 if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('service-worker.js');
+    navigator.serviceWorker.register(`${pathPrefix}service-worker.js`);
 }
+
+let translations = {};
+
+function t(key, vars = {}) {
+    let str = translations[key] || key;
+    return str.replace(/\{(\w+)\}/g, (_, v) => (vars[v] !== undefined ? vars[v] : ''));
+}
+
+async function loadTranslations() {
+    const lang = document.documentElement.lang || 'fr';
+    try {
+        const res = await fetch(`${pathPrefix}i18n/${lang}.json`);
+        translations = await res.json();
+    } catch (e) {
+        console.error('Translation load error', e);
+    }
+}
+
+const translationsLoaded = loadTranslations();
+
+function initGeolocation() {
+    if (navigator.geolocation) {
+        navigator.geolocation.watchPosition(
+            pos => {
+                const { latitude, longitude } = pos.coords;
+                const heading = pos.coords.heading; // Récupérer la direction
+                lastPositionTimestamp = Date.now();
+
+                lastGpsPosition = {
+                    lat: latitude,
+                    lng: longitude,
+                    heading: hasDeviceOrientation ? deviceHeading : heading
+                };
+                gpsWaitingNotificationUserHidden = false; // Réinitialiser le flag si on reçoit une position
+                gpsSignalLost = false;
+                showGpsDot();
+            },
+            err => {
+                console.log(t('geolocation_error', { code: err.code, message: err.message }));
+            },
+            { enableHighAccuracy: true, maximumAge: 10000, timeout: 10000 }
+        );
+    } else {
+        console.log(t('geolocation_unsupported'));
+    }
+}
+
+translationsLoaded.then(initGeolocation);
 
 // Gestion du mode plein écran
 function toggleFullScreen() {
@@ -547,31 +596,6 @@ let lastPositionTimestamp = null;
 const GPS_TIMEOUT = 10000; // 10 secondes sans nouvelle position = signal perdu
 let gpsWaitingNotificationUserHidden = false;
 
-if (navigator.geolocation) {
-    navigator.geolocation.watchPosition(
-        pos => {
-            const { latitude, longitude } = pos.coords;
-            const heading = pos.coords.heading; // Récupérer la direction
-            lastPositionTimestamp = Date.now();
-            
-            lastGpsPosition = {
-                lat: latitude,
-                lng: longitude,
-                heading: hasDeviceOrientation ? deviceHeading : heading
-            };
-            gpsWaitingNotificationUserHidden = false; // Réinitialiser le flag si on reçoit une position
-            gpsSignalLost = false;
-            showGpsDot();
-        },
-        err => {
-            console.log(`Erreur de géolocalisation : ${err.code} - ${err.message}`);
-        },
-        { enableHighAccuracy: true, maximumAge: 10000, timeout: 10000 }
-    );
-} else {
-    console.log("La géolocalisation n'est pas supportée par ce navigateur.");
-}
-
 setInterval(() => {
     if (gpsWaitingNotificationUserHidden) return; // Ne pas afficher si l'utilisateur a masqué la notification
     if (!lastPositionTimestamp || Date.now() - lastPositionTimestamp > GPS_TIMEOUT) {
@@ -600,7 +624,8 @@ const resizeObserver = new ResizeObserver((entries) => {
 resizeObserver.observe(document.documentElement);
 
 // Enregistrement des événements ici pour s'assurer que le DOM est prêt
-document.addEventListener('DOMContentLoaded', function () {
+document.addEventListener('DOMContentLoaded', async function () {
+    await translationsLoaded;
     // Gérer les changements de visibilité du document
     document.addEventListener('visibilitychange', () => {
         if (!document.hidden && lastGpsPosition) {
@@ -632,8 +657,8 @@ document.addEventListener('DOMContentLoaded', function () {
                 const restoreBtn = document.createElement('button');
                 restoreBtn.className = 'panel-restore-btn';
                 restoreBtn.id = 'out-of-bounds-restore-btn';
-                restoreBtn.title = "Agrandir";
-                restoreBtn.ariaLabel = "Agrandir";
+                restoreBtn.title = t('expand');
+                restoreBtn.ariaLabel = t('expand');
                 restoreBtn.innerHTML = `
 <svg width="38" height="38" viewBox="0 0 24 24">
   <path fill="#000000" d="M7.41 15.41 12 10.83l4.59 4.58L18 14l-6-6-6 6z"/>

--- a/www/manifest.json
+++ b/www/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Carte du zoo du Lunaret",
   "short_name": "LunaretMap",
-  "start_url": ".",
+  "start_url": "index.html",
   "display": "standalone",
   "background_color": "#f7f7f7",
   "theme_color": "#4CAF50",

--- a/www/nl-be/index.html
+++ b/www/nl-be/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="nl-BE">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Interactieve kaart van de Zoo van Lunaret met realtime geolocatie. Verken de zoo en vind gemakkelijk je weg.">
+  <title>Interactieve kaart van de Zoo van Lunaret</title>
+  <link rel="stylesheet" href="../styles.css?v=5">
+  <link rel="manifest" href="../manifest.json">
+  <link rel="icon" type="image/x-icon" href="../favicon.ico">
+  <link rel="alternate" hreflang="fr" href="../index.html">
+  <link rel="alternate" hreflang="en" href="../en/index.html">
+  <link rel="alternate" hreflang="es" href="../es/index.html">
+  <link rel="alternate" hreflang="nl-BE" href="./index.html">
+</head>
+<body>
+  <div id="map-container">
+    <img id="carte" src="../img/plan.webp" alt="Kaart van de Zoo van Lunaret" class="fullscreen-img">
+    <canvas id="trail-canvas"></canvas>    
+  </div>
+  <div id="out-of-bounds-panel">    
+    <div class="panel-content">
+      <div class="panel-text">Je bevindt je buiten het park, volg de pijl</div>
+      <div class="arrow-container">
+        <svg id="direction-arrow" width="60" height="60" viewBox="0 0 60 60">
+          <polygon points="30,8 40,38 30,32 20,38" fill="#007bff" stroke="#333" stroke-width="2" />
+        </svg>
+      </div>
+    </div>
+    <button class="panel-hide-btn" id="out-of-bounds-hide-btn" aria-label="Paneel minimaliseren" title="Minimaliseren">
+      <svg width="38" height="38" viewBox="0 0 24 24">
+        <path fill="#000000" d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z"/>
+      </svg>
+    </button>
+  </div>
+  <button id="fullscreen-btn" aria-label="Volledig scherm">
+    <svg viewBox="0 0 24 24" width="24" height="24">
+      <path fill="currentColor" d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>
+    </svg>
+  </button>
+  <div id="gps-waiting-notification">
+    <button class="hide-btn" id="gps-notif-hide" title="Melding verbergen">Verbergen</button>
+      Wachten op GPS-signaal…
+  </div>
+</body>
+<script src="../index.js?v=7"></script>
+</html>

--- a/www/service-worker.js
+++ b/www/service-worker.js
@@ -1,9 +1,15 @@
-const CACHE_NAME = 'lunaretmap-cache-v2';
+const CACHE_NAME = 'lunaretmap-cache-v4';
 const urlsToCache = [
-  '',
   'index.html',
+  'en/index.html',
+  'es/index.html',
+  'nl-be/index.html',
   'index.js',
   'styles.css',
+  'i18n/fr.json',
+  'i18n/en.json',
+  'i18n/es.json',
+  'i18n/nl-BE.json',
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- Localize site into French, English, Spanish and Belgian Dutch with language-specific directories and hreflang links.
- Externalize JS strings to JSON files and load translations dynamically.
- Update service worker cache and manifest to accommodate new localized pages.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b634a96c083209472bc68b5a014a7